### PR TITLE
Fix CMake rules for vita-toolchain

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -249,10 +249,8 @@ make install
 cd ..
 mkdir build-vita-toolchain && cd build-vita-toolchain
 cmake $SRCDIR/$VITA_TOOLCHAIN \
-	-DJansson_INCLUDE_DIR=$BUILDDIR_NATIVE/vita-toolchain/install/include/ \
-	-DJansson_LIBRARY=$BUILDDIR_NATIVE/vita-toolchain/install/lib/libjansson.a \
-	-Dlibelf_INCLUDE_DIR=$BUILDDIR_NATIVE/vita-toolchain/install/include/ \
-	-Dlibelf_LIBRARY=$BUILDDIR_NATIVE/vita-toolchain/install/lib/libelf.a \
+	-DINCLUDE_DIR=$BUILDDIR_NATIVE/vita-toolchain/install/include/ \
+	-DLINK_DIR=$BUILDDIR_NATIVE/vita-toolchain/install/lib/ \
 	-DUSE_BUNDLED_ENDIAN_H=ON \
 	-DCMAKE_INSTALL_PREFIX=$INSTALLDIR_NATIVE
 make


### PR DESCRIPTION
This passes the directories for includes and libraries directly to cmake so it doesn't have to find them. This requires a change in vita-toolchain to correspond, but eliminates the need for using an old version of Ubuntu for building.
