### PR TITLE
Revert "Link against SceRtc by default so newlib can implement time()"

### DIFF
--- a/vita.patch
+++ b/vita.patch
@@ -21,7 +21,7 @@ diff -ru ../../gcc-arm-none-eabi-4_9-2015q2-20150609/src/gcc/gcc/gcc.c ./gcc/gcc
 +#undef LIB_SPEC
  #ifndef LIB_SPEC
 -#define LIB_SPEC "%{!shared:%{g*:-lg} %{!p:%{!pg:-lc}}%{p:-lc_p}%{pg:-lc_p}}"
-+#define LIB_SPEC "%{!shared:%{g*:-lg} %{!p:%{!pg:-lc}}%{p:-lc_p}%{pg:-lc_p}} -lSceRtc_stub -lSceKernel_stub -lUVLoader_stub"
++#define LIB_SPEC "%{!shared:%{g*:-lg} %{!p:%{!pg:-lc}}%{p:-lc_p}%{pg:-lc_p}} -lSceKernel_stub -lUVLoader_stub"
  #endif
  
  /* When using -fsplit-stack we need to wrap pthread_create, in order


### PR DESCRIPTION
Reverts xyzz/vitasdk-buildscripts#8
